### PR TITLE
feat(notifee): Event listeners with M1 support

### DIFF
--- a/NotifeeApp.js
+++ b/NotifeeApp.js
@@ -6,13 +6,25 @@
  * @flow
  */
 
-import React, { Component } from "react";
+import React, { useEffect } from "react";
 import { Button, Platform, StyleSheet, Text, View } from "react-native";
 import notifee, {
   AndroidLaunchActivityFlag,
   IOSAuthorizationStatus,
-  IOSNotificationPermissions,
+  EventType,
 } from "@notifee/react-native";
+
+notifee.onBackgroundEvent(async ({ type, detail }) => {
+  const { notification, pressAction } = detail;
+  console.log(`[onBackgroundEvent] notification id: ${notification.id},  event type: ${EventType[type]}, press action: ${pressAction?.id}`);
+  // Check if the user pressed the "Mark as read" action
+  if (type === EventType.ACTION_PRESS && pressAction.id === 'mark-as-read') {
+    console.log('[onBackgroundEvent] ACTION_PRESS: mark-as-read');
+
+    // Remove the notification
+    await notifee.cancelNotification(notification.id);
+  }
+});
 
 async function onDisplayNotification() {
   // Create a channel
@@ -54,6 +66,59 @@ async function onDisplayNotification() {
   }
 }
 
+async function setCategories() {
+  await notifee.setNotificationCategories([
+    {
+      id: 'post',
+      actions: [
+        {
+          id: 'like',
+          title: 'Like Post',
+        },
+        {
+          id: 'dislike',
+          title: 'Dislike Post',
+        },
+      ],
+    },
+  ]);
+}
+
+async function onDisplayNotificationWithActions() {
+  // Create a channel
+  try {
+    const channelId = await notifee.createChannel({
+      id: "default",
+      name: "Default Channel",
+    });
+
+    const settings = await notifee.requestPermission();
+
+    if (settings.authorizationStatus === IOSAuthorizationStatus.DENIED) {
+      console.log("User denied permissions request");
+    } else if (
+      settings.authorizationStatus === IOSAuthorizationStatus.AUTHORIZED
+    ) {
+      console.log("User granted permissions request");
+    } else if (
+      settings.authorizationStatus === IOSAuthorizationStatus.PROVISIONAL
+    ) {
+      console.log("User provisionally granted permissions request");
+    }
+
+    // Display a notification
+    await notifee.displayNotification({
+      title: 'New post from John',
+      body: 'Hey everyone! Check out my new blog post on my website.',
+      ios: {
+        categoryId: 'post',
+      },
+    });
+  } catch (e) {
+    console.log("Failed to display notification?", e);
+  }
+}
+
 const instructions = Platform.select({
   ios: "Press Cmd+R to reload,\n" + "Cmd+D or shake for dev menu",
   android:
@@ -61,20 +126,43 @@ const instructions = Platform.select({
     "Shake or press menu button for dev menu",
 });
 
-export default class App extends Component {
-  render() {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.welcome}>Notifee React Native Demo</Text>
-        <Text style={styles.instructions}>To get started, edit App.js</Text>
-        <Text style={styles.instructions}>{instructions}</Text>
+export default function App() {
+  useEffect(() => {
+    setCategories();
+    return notifee.onForegroundEvent(({ type, detail }) => {
+      const { notification, pressAction } = detail;
+      const pressActionLabel = pressAction ? `, press action: ${pressAction?.id}` : '';
+      console.log(`[onForegroundEvent] notification id: ${notification.id},  event type: ${EventType[type]}${pressActionLabel}`);
+
+      switch (type) {
+        case EventType.DISMISSED:
+          console.log('[onForegroundEvent] User dismissed notification', notification);
+          break;
+        case EventType.PRESS:
+          console.log('[onForegroundEvent] User pressed notification', notification);
+          break;
+        case EventType.ACTION_PRESS:
+          console.log('[onForegroundEvent] User pressed an action', notification, detail.pressAction);
+          break;
+      }
+    });
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.welcome}>Notifee React Native Demo</Text>
+      <Text style={styles.instructions}>To get started, edit App.js</Text>
+      <Text style={styles.instructions}>{instructions}</Text>
+      <Button
+        title="Display Notification"
+        onPress={() => onDisplayNotification()}
+      />
         <Button
-          title="Display Notification"
-          onPress={() => onDisplayNotification()}
-        />
-      </View>
-    );
-  }
+        title="Display Notification With Actions"
+        onPress={() => onDisplayNotificationWithActions()}
+      />
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/NotifeeApp.js
+++ b/NotifeeApp.js
@@ -157,7 +157,7 @@ export default function App() {
         title="Display Notification"
         onPress={() => onDisplayNotification()}
       />
-        <Button
+      <Button
         title="Display Notification With Actions"
         onPress={() => onDisplayNotificationWithActions()}
       />

--- a/notifee-demo.sh
+++ b/notifee-demo.sh
@@ -9,7 +9,14 @@ npx react-native init notifeedemo
 cd notifeedemo
 
 # I have problems in my country with the cocoapods CDN sometimes, use github directly
-sed -i -e $'s/def add_flipper_pods/source \'https:\/\/github.com\/CocoaPods\/Specs.git\'\\\n\\\ndef add_flipper_pods/' ios/Podfile
+if [ "$(uname -m)" == "arm64" ]; then
+  echo "arm64 detected, disabling flipper"
+  sed -i -e 's/use_flipper/#&/' ios/Podfile
+  sed -i -e 's/flipper_post_install/#&/' ios/Podfile
+else
+  sed -i -e $'s/def add_flipper_pods/source \'https:\/\/github.com\/CocoaPods\/Specs.git\'\\\n\\\ndef add_flipper_pods/' ios/Podfile
+fi
+
 rm -f ios/Podfile.??
 
 # This is the most basic integration
@@ -43,7 +50,12 @@ rm ./App.js && cp ../NotifeeApp.js ./App.js
 # Run the thing for iOS
 if [ "$(uname)" == "Darwin" ]; then
   echo "Installing pods and running iOS app"
-  cd ios && pod install --repo-update && cd ..
+  if [ "$(uname -m)" == "arm64" ]; then
+    echo "Installing pods with prefix arch -arch x86_64"
+    cd ios && arch -arch x86_64 pod install && cd ..
+  else
+    cd ios && pod install --repo-update && cd ..
+  fi
   npx react-native run-ios
   # workaround for poorly setup Android SDK environments
   USER=`whoami`


### PR DESCRIPTION
Updated `notifee-demo.sh` with a couple of things:
1. disabled flipper, there's no support currently for M1 https://github.com/facebook/flipper/issues/1758
2.  Added `arch -arch x86_64` before `pod install`. Not needed if developer has install `ffi` globally but it helps to have it there to ensure it works (https://github.com/CocoaPods/CocoaPods/issues/10220).
3. Removed `--repo-update`

Added event listeners for `onForegroundEvent` and `onBackgroundEvent`
![example-output](https://user-images.githubusercontent.com/14185925/106394795-6acf3080-63f6-11eb-92f2-f15a15dc7f9f.png)
